### PR TITLE
fix/chore: strategyHelper DEV警告・順序依存コメント・Beam getOutputConfig 未定義ケース補完

### DIFF
--- a/src/components/cards/Beam.tsx
+++ b/src/components/cards/Beam.tsx
@@ -327,6 +327,22 @@ export const BeamCardDef = createStrategyDefinition<BeamOutputs>({
                     M_max: { label: '最大曲げモーメント（固定端）', unitType: 'moment', formula: 'w × L² / 8',  symbol: 'M_max', formulaInputKeys: ['w', 'L'] },
                     V_max: { label: '最大せん断力（固定端）',       unitType: 'force',  formula: '5 × w × L / 8', symbol: 'V_max', formulaInputKeys: ['w', 'L'] },
                 };
+            case 'fixed_fixed::moment':
+                return {
+                    M_max: { label: '最大曲げモーメント', unitType: 'moment', formula: 'M₀ × max(a, L−a) / L', symbol: 'M_max', formulaInputKeys: ['M0', 'a', 'L'] },
+                    V_max: { label: '最大せん断力',       unitType: 'force',  formula: '|M₀| / L',             symbol: 'V_max', formulaInputKeys: ['M0', 'L'] },
+                };
+            case 'fixed_pinned::point':
+                return {
+                    // MA = P×a×b×(2L−a)/(2L²), RA = P×b×(3L²−b²)/(2L³), b=L−a
+                    M_max: { label: '最大曲げモーメント（固定端）', unitType: 'moment', formula: 'P × a × b × (2L−a) / (2L²)', symbol: 'M_max', formulaInputKeys: ['P', 'a', 'L'] },
+                    V_max: { label: '最大せん断力（固定端）',       unitType: 'force',  formula: 'P × b × (3L²−b²) / (2L³)', symbol: 'V_max', formulaInputKeys: ['P', 'a', 'L'] },
+                };
+            case 'fixed_pinned::moment':
+                return {
+                    M_max: { label: '最大曲げモーメント', unitType: 'moment', formula: 'M₀ × max(a, L−a) / L', symbol: 'M_max', formulaInputKeys: ['M0', 'a', 'L'] },
+                    V_max: { label: '最大せん断力',       unitType: 'force',  formula: '|M₀| / L',             symbol: 'V_max', formulaInputKeys: ['M0', 'L'] },
+                };
             default:
                 return {} as Record<string, never>;
         }

--- a/src/lib/registry/strategyHelper.ts
+++ b/src/lib/registry/strategyHelper.ts
@@ -178,9 +178,21 @@ export function createStrategyDefinition<TOutputs extends Record<string, any> = 
         }
 
         // Multi-axis: compose by joining axis values with '::'
+        // NOTE: axis order in strategyAxes determines the strategy ID composition.
+        // e.g. { boundary, load } → "simple::uniform" (ES2015+ preserves string key insertion order).
+        // Reordering keys in strategyAxes would break serialization compatibility with saved projects.
         const parts = axisEntries.map(([key, field]) => String((inputs[key]?.value || field.default) ?? ''));
         return parts.join('::');
     };
+
+    // DEV: warn if any axis has no default value (silent fallback to '' causes strategy ID mismatch)
+    if (import.meta.env.DEV) {
+        for (const [key, field] of axisEntries) {
+            if (field.default === undefined) {
+                console.warn(`[CardDef:${type}] strategyAxes["${key}"] has no default value — falling back to ''`);
+            }
+        }
+    }
 
     // DEV: validate strategy IDs are reachable
     if (import.meta.env.DEV) {


### PR DESCRIPTION
## 対応 issue

- closes #17
- closes #18
- closes #19

## 変更内容

### `src/lib/registry/strategyHelper.ts`

- **#17**: `createStrategyDefinition` 内に DEV 警告を追加。`strategyAxes` のいずれかの axis で `field.default` が `undefined` の場合、`''` にサイレントフォールバックして ID ミスマッチを引き起こす前に `console.warn` を出力する。
- **#18**: `resolveStrategyId` の multi-axis 合成箇所に注意コメントを追加。`Object.entries()` の挿入順序に依存していること、キー順を変えるとシリアライズ互換性が壊れることを明示。

### `src/components/cards/Beam.tsx`

- **#19**: `getOutputConfig` の `switch` 文に以下3ケースを追加。未定義のまま `default: return {}` にフォールバックしていたため、計算書出力で公式が空欄になっていた。
  - `fixed_fixed::moment`: `M_max ≈ M₀ × max(a, L−a) / L`（近似）、`V_max = |M₀| / L`
  - `fixed_pinned::point`: `MA = P×a×b×(2L−a)/(2L²)`、`RA = P×b×(3L²−b²)/(2L³)`（beam.ts の解析式から導出）
  - `fixed_pinned::moment`: `M_max ≈ M₀ × max(a, L−a) / L`（近似）、`V_max = |M₀| / L`

## Test plan

- [ ] `npx tsc --noEmit` が通ること（lint の `no-explicit-any` 45件は #16 対応範囲のため本PRでは対象外）
- [ ] BEAM カードで `fixed_fixed::moment` / `fixed_pinned::point` / `fixed_pinned::moment` に切り替えたとき、計算書出力に公式が表示されること
- [ ] DEV モードで `sel()` の `default` を省略した CardDef を追加すると console.warn が出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)