### PR TITLE
fix: @typescript-eslint/no-explicit-any を解消（型システム強化）

### DIFF
--- a/src/components/cards/SectionHSelect.tsx
+++ b/src/components/cards/SectionHSelect.tsx
@@ -1,5 +1,6 @@
 
 import { RectangleHorizontal } from 'lucide-react';
+import type { CardInput } from '../../types';
 import type { CardDefinition } from '../../lib/registry/types';
 import { num, sel } from '../../lib/utils/inputField';
 import { createVisualizationComponent, type VisualizationStrategy } from './common/visualizationHelper';
@@ -102,7 +103,7 @@ const SectionHSelectVisualization = createVisualizationComponent({
     height: 240,
     padding: 40,
     transformInputs: (rawInputs) => {
-        const sectionName = rawInputs['section']?.value ?? '';
+        const sectionName = String(rawInputs['section']?.value ?? '');
         const sec = findHSection(sectionName) ?? H_SECTIONS[0];
         return { H: sec.H, B: sec.B, tw: sec.tw, tf: sec.tf };
     },
@@ -110,8 +111,8 @@ const SectionHSelectVisualization = createVisualizationComponent({
 
 // --- Calculation ---
 
-function calcHSection(inputs: Record<string, number>, rawInputs?: Record<string, any>): SectionHSelectOutputs {
-    const sectionName = rawInputs?.['section']?.value ?? '';
+function calcHSection(inputs: Record<string, number>, rawInputs?: Record<string, CardInput>): SectionHSelectOutputs {
+    const sectionName = String(rawInputs?.['section']?.value ?? '');
     const sec = findHSection(sectionName);
     if (!sec) {
         throw new Error(`断面 "${sectionName}" が見つかりません。フランジ幅カテゴリを変更した場合は断面形状を再選択してください。`);

--- a/src/components/cards/common/GenericCard.tsx
+++ b/src/components/cards/common/GenericCard.tsx
@@ -7,6 +7,8 @@ import { SmartInput } from '../../common/SmartInput';
 import { formatOutput, getUnitLabel, type OutputUnitType, type UnitMode } from '../../../lib/utils/unitFormatter';
 import type { CardComponentProps, CardActions, DynamicInputGroupConfig, DynamicMultiGroupConfig, DynamicMultiGroupFieldConfig } from '../../../lib/registry/types';
 import type { Card } from '../../../types';
+import type { NumericInputField, SelectInputField } from '../../../lib/utils/inputField';
+import type { SmartInputUnitType } from '../../../lib/utils/unitFormatter';
 import { registry } from '../../../lib/registry';
 import { useTsumikiStore } from '../../../store/useTsumikiStore';
 import { ja, type JaKey } from '../../../lib/i18n/ja';
@@ -14,7 +16,7 @@ import { ja, type JaKey } from '../../../lib/i18n/ja';
 const isJaKey = (key: string): key is JaKey => key in ja;
 const t = (key: string): string => isJaKey(key) ? ja[key] : key;
 
-const SelectInput = ({ name, config, card, actions }: { name: string, config: any, card: any, actions: any }) => (
+const SelectInput = ({ name, config, card, actions }: { name: string, config: SelectInputField, card: Card, actions: CardActions }) => (
     <div className="flex flex-col gap-1 w-full">
         <label className="text-[10px] font-bold text-slate-400 uppercase tracking-wider">
             {config.symbol && <span className="font-mono text-slate-400 text-xs mr-1">{config.symbol}</span>}
@@ -26,7 +28,7 @@ const SelectInput = ({ name, config, card, actions }: { name: string, config: an
                 value={card.inputs[name]?.value || config.default || ''}
                 onChange={(e) => actions.updateInput(card.id, name, e.target.value)}
             >
-                {config.options?.map((opt: any) => (
+                {config.options?.map((opt) => (
                     <option key={opt.value} value={opt.value}>{opt.label}</option>
                 ))}
             </select>
@@ -39,10 +41,10 @@ const SelectInput = ({ name, config, card, actions }: { name: string, config: an
 
 const InputRow = ({ name, config, card, actions, upstreamCards, unitMode, upstreamInputConfigs, isPinned, onPinToggle }: {
     name: string;
-    config: any;
-    card: any;
-    actions: any;
-    upstreamCards: any;
+    config: NumericInputField;
+    card: Card;
+    actions: CardActions;
+    upstreamCards: Card[];
     unitMode: UnitMode;
     upstreamInputConfigs?: Map<string, Record<string, { label: string; unitType?: OutputUnitType }>>;
     isPinned: boolean;
@@ -78,7 +80,7 @@ const InputRow = ({ name, config, card, actions, upstreamCards, unitMode, upstre
                     upstreamInputConfigs={upstreamInputConfigs}
                     placeholder={unitLabel ? '0' : ''}
                     unitMode={unitMode}
-                    inputType={config.unitType as any}
+                    inputType={config.unitType as SmartInputUnitType}
                 />
             </div>
         </div>
@@ -160,7 +162,7 @@ const DynamicGroupSection = ({
                                     actions={actions}
                                     upstreamCards={upstreamCards}
                                     upstreamInputConfigs={upstreamInputConfigs}
-                                    inputType={inputUnitType as any}
+                                    inputType={inputUnitType as SmartInputUnitType}
                                     unitMode={unitMode}
                                     placeholder="0"
                                 />
@@ -325,7 +327,7 @@ export const DynamicMultiGroupSection = ({
                                                     actions={actions}
                                                     upstreamCards={upstreamCards}
                                                     upstreamInputConfigs={upstreamInputConfigs}
-                                                    inputType={resolvedUnitType as any}
+                                                    inputType={resolvedUnitType as SmartInputUnitType}
                                                     unitMode={unitMode}
                                                     placeholder="0"
                                                 />
@@ -353,7 +355,7 @@ const OutputRow = ({
 }: {
     name: string;
     config: { label: string; unitType: OutputUnitType; symbol?: string };
-    card: any;
+    card: Card;
     unitMode: UnitMode;
     isPinned: boolean;
     onPinToggle: () => void;
@@ -402,8 +404,8 @@ const GenericCardInner: React.FC<CardComponentProps> = ({ card, actions, upstrea
     const resolvedInputConfig = { ...(def.inputConfig || {}), ...dynamicConfig };
 
     // Split inputs into Selectors and Standard Inputs
-    const selectors = Object.entries(resolvedInputConfig).filter(([, config]) => config.kind === 'select');
-    const standardInputs = Object.entries(resolvedInputConfig).filter(([, config]) => config.kind !== 'select');
+    const selectors = Object.entries(resolvedInputConfig).filter((e): e is [string, SelectInputField] => e[1].kind === 'select');
+    const standardInputs = Object.entries(resolvedInputConfig).filter((e): e is [string, NumericInputField] => e[1].kind !== 'select');
 
     return (
         <BaseCard card={card} icon={<def.icon size={18} />} color="border-slate-400">

--- a/src/components/cards/common/ResultsPanel.tsx
+++ b/src/components/cards/common/ResultsPanel.tsx
@@ -16,7 +16,7 @@ export interface ResultField {
 
 interface ResultsPanelProps {
     cardId: string;
-    outputs: Record<string, any>;
+    outputs: Record<string, number>;
     fields: ResultField[];
     unitMode: UnitMode;
 }

--- a/src/components/cards/common/visualizationHelper.tsx
+++ b/src/components/cards/common/visualizationHelper.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import React from 'react';
+import type { CardInput } from '../../../types';
 import type { CardComponentProps } from '../../../lib/registry/types';
 import { AutoFitSvg } from './AutoFitSvg';
 import type { DimensionDef } from './AutoFitSvg';
@@ -33,12 +34,12 @@ interface StrategyAxis {
 
 interface CreateVisualizationOptions {
     strategyAxes: StrategyAxis[];
-    strategies: VisualizationStrategy<any>[];
+    strategies: VisualizationStrategy<Record<string, number>>[];
 
     // Optional: Transform raw card inputs to typed inputs
     // Default: Converts all values to numbers
     // resolvedInputs (2nd arg) contains post-reference-resolution values
-    transformInputs?: (inputs: Record<string, any>, resolvedInputs: Record<string, number>) => any;
+    transformInputs?: (inputs: Record<string, CardInput>, resolvedInputs: Record<string, number>) => Record<string, number>;
 
     // Optional: Default/Initial bounds if strategy undefined (unlikely)
     defaultBounds?: { minX: number; minY: number; maxX: number; maxY: number };
@@ -61,7 +62,7 @@ export function createVisualizationComponent(options: CreateVisualizationOptions
     return ({ card }) => {
         // 1. Extract & Transform Inputs
         const rawInputs = card.inputs;
-        let inputs: any;
+        let inputs: Record<string, number>;
 
         const resolved = card.resolvedInputs ?? {};
         if (transformInputs) {

--- a/src/components/stack/SortableItemContext.ts
+++ b/src/components/stack/SortableItemContext.ts
@@ -1,8 +1,8 @@
 import { createContext, useContext } from 'react';
-import type { DraggableSyntheticListeners } from '@dnd-kit/core';
+import type { DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core';
 
 export interface SortableItemContextProps {
-    attributes: Record<string, any>;
+    attributes: DraggableAttributes;
     listeners: DraggableSyntheticListeners;
     setNodeRef: (element: HTMLElement | null) => void;
     style: React.CSSProperties;
@@ -11,7 +11,14 @@ export interface SortableItemContextProps {
 }
 
 export const SortableItemContext = createContext<SortableItemContextProps>({
-    attributes: {},
+    attributes: {
+        role: 'button',
+        tabIndex: 0,
+        'aria-disabled': false,
+        'aria-pressed': undefined,
+        'aria-roledescription': 'sortable',
+        'aria-describedby': '',
+    },
     listeners: undefined,
     setNodeRef: () => { },
     style: {},

--- a/src/lib/registry/registry.ts
+++ b/src/lib/registry/registry.ts
@@ -1,20 +1,20 @@
-import type { CardDefinition } from './types';
+import type { CardDefinition, CardOutputRecord } from './types';
 
 class CardRegistry {
-    private definitions: Map<string, CardDefinition<any>> = new Map();
+    private definitions: Map<string, CardDefinition<CardOutputRecord>> = new Map();
 
-    register(def: CardDefinition<any>) {
+    register(def: CardDefinition<CardOutputRecord>) {
         if (this.definitions.has(def.type)) {
             console.warn(`Card type ${def.type} is already registered. Overwriting.`);
         }
         this.definitions.set(def.type, def);
     }
 
-    get(type: string): CardDefinition<any> | undefined {
+    get(type: string): CardDefinition<CardOutputRecord> | undefined {
         return this.definitions.get(type);
     }
 
-    getAll(): CardDefinition<any>[] {
+    getAll(): CardDefinition<CardOutputRecord>[] {
         return Array.from(this.definitions.values());
     }
 

--- a/src/lib/registry/strategyHelper.ts
+++ b/src/lib/registry/strategyHelper.ts
@@ -1,4 +1,6 @@
-import type { CardDefinition, CardStrategy } from './types';
+import type { LucideIcon } from 'lucide-react';
+import type { CardInput } from '../../types';
+import type { CardDefinition, CardStrategy, CardComponentProps, CardOutputRecord } from './types';
 import { type InputFieldConfig, type SelectInputField } from '../utils/inputField';
 
 
@@ -45,7 +47,7 @@ function validateCardDefinition(def: CardDefinition, context: string): void {
             const dummyInputs: Record<string, number> = {};
             if (def.defaultInputs) {
                 for (const [k, v] of Object.entries(def.defaultInputs)) {
-                    dummyInputs[k] = typeof v === 'object' && v !== null ? (parseFloat(v.value) || 0) : (parseFloat(v) || 0);
+                    dummyInputs[k] = parseFloat(String(v.value)) || 0;
                 }
             }
             const result = def.calculate(dummyInputs, def.defaultInputs);
@@ -105,16 +107,16 @@ function validateCardDefinition(def: CardDefinition, context: string): void {
 }
 
 
-interface StrategyDefinitionOptions<TOutputs extends Record<string, any> = Record<string, number>> {
+interface StrategyDefinitionOptions<TOutputs extends CardOutputRecord = Record<string, number>> {
     type: string;
     title: string;
-    icon: React.FC<any>;
+    icon: LucideIcon;
     description?: string;
 
     strategyAxes: Record<string, SelectInputField>;
 
     strategies: CardStrategy<TOutputs>[];
-    commonInputs?: Record<string, any>;
+    commonInputs?: Record<string, CardInput>;
     /**
      * Input fields shared across all strategies. Merged with each strategy's own
      * inputConfig in getInputConfig (strategy-specific fields take precedence).
@@ -122,13 +124,13 @@ interface StrategyDefinitionOptions<TOutputs extends Record<string, any> = Recor
     commonInputConfig?: CardDefinition<TOutputs>['inputConfig'];
     outputConfig: CardDefinition<TOutputs>['outputConfig'];
     getOutputConfig?: CardDefinition<TOutputs>['getOutputConfig'];
-    visualization?: React.FC<any>;
-    reportVisualization?: React.FC<any>;
+    visualization?: React.FC<CardComponentProps>;
+    reportVisualization?: React.FC<CardComponentProps>;
     sidebar?: CardDefinition<TOutputs>['sidebar'];
     shouldRenderInput?: CardDefinition<TOutputs>['shouldRenderInput'];
 }
 
-export function createStrategyDefinition<TOutputs extends Record<string, any> = Record<string, number>>(options: StrategyDefinitionOptions<TOutputs>): CardDefinition<TOutputs> {
+export function createStrategyDefinition<TOutputs extends CardOutputRecord = Record<string, number>>(options: StrategyDefinitionOptions<TOutputs>): CardDefinition<TOutputs> {
     const {
         type,
         title,
@@ -156,18 +158,18 @@ export function createStrategyDefinition<TOutputs extends Record<string, any> = 
     }
 
     // Construct default inputs for all axes
-    const axisDefaults: Record<string, any> = {};
+    const axisDefaults: Record<string, CardInput> = {};
     axisEntries.forEach(([key, field]) => {
         axisDefaults[key] = { value: field.default ?? '' };
     });
 
-    const defaultInputs: Record<string, any> = {
+    const defaultInputs: Record<string, CardInput> = {
         ...axisDefaults,
         ...commonInputs
     };
 
     // Helper to resolve Strategy ID from inputs
-    const resolveStrategyId = (inputs: Record<string, any> | undefined): string => {
+    const resolveStrategyId = (inputs: Record<string, CardInput> | undefined): string => {
         if (!inputs) return defaultStrategy.id;
 
         // Single axis: ID is the axis value directly
@@ -253,19 +255,19 @@ export function createStrategyDefinition<TOutputs extends Record<string, any> = 
 }
 
 
-interface SimpleCardDefinitionOptions<TOutputs extends Record<string, any> = Record<string, number>> {
+interface SimpleCardDefinitionOptions<TOutputs extends CardOutputRecord = Record<string, number>> {
     type: string;
     title: string;
-    icon: React.FC<any>;
+    icon: LucideIcon;
     description?: string;
-    defaultInputs?: Record<string, any>;
+    defaultInputs?: Record<string, CardInput>;
     inputConfig?: CardDefinition<TOutputs>['inputConfig'];
     outputConfig: CardDefinition<TOutputs>['outputConfig'];
     calculate: CardDefinition<TOutputs>['calculate'];
     /** Render inside GenericCard's visualization area (SVG box). */
-    visualization?: React.FC<any>;
+    visualization?: React.FC<CardComponentProps>;
     /** Visualization component used exclusively for report generation (custom-component cards). */
-    reportVisualization?: React.FC<any>;
+    reportVisualization?: React.FC<CardComponentProps>;
     /** Replace GenericCard entirely. Use when inputs/outputs are dynamic or layout needs full control. */
     component?: CardDefinition<TOutputs>['component'];
     /** Variable-length paired (input → output) row groups rendered by GenericCard. */
@@ -277,7 +279,7 @@ interface SimpleCardDefinitionOptions<TOutputs extends Record<string, any> = Rec
     shouldRenderInput?: CardDefinition<TOutputs>['shouldRenderInput'];
 }
 
-export function createCardDefinition<TOutputs extends Record<string, any> = Record<string, number>>(options: SimpleCardDefinitionOptions<TOutputs>): CardDefinition<TOutputs> {
+export function createCardDefinition<TOutputs extends CardOutputRecord = Record<string, number>>(options: SimpleCardDefinitionOptions<TOutputs>): CardDefinition<TOutputs> {
     const {
         type,
         title,

--- a/src/lib/registry/types.ts
+++ b/src/lib/registry/types.ts
@@ -1,13 +1,23 @@
 import React from 'react';
-import type { Card } from '../../types';
+import type { LucideIcon } from 'lucide-react';
+import type { Card, CardInput } from '../../types';
 import type { InputFieldConfig } from '../utils/inputField';
 import type { SmartInputUnitType } from '../utils/unitFormatter';
+
+/**
+ * Upper bound for card output type parameters.
+ * Using `any` as the value type is intentional: card output interfaces don't
+ * carry an explicit index signature, so `Record<string, unknown>` would
+ * reject them at the constraint check site.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type CardOutputRecord = Record<string, any>;
 
 export type { SmartInputUnitType };
 
 // Actions passed to components (Decoupled from Store)
 export interface CardActions {
-    updateInput: (cardId: string, key: string, value: any) => void;
+    updateInput: (cardId: string, key: string, value: string | number) => void;
     setReference: (cardId: string, inputKey: string, sourceCardId: string, outputKey: string) => void;
     setInputReference: (cardId: string, inputKey: string, sourceCardId: string, sourceInputKey: string) => void;
     setRefExpression: (cardId: string, inputKey: string, expression: string) => void;
@@ -25,7 +35,7 @@ export interface CardComponentProps {
 
 // TOutputs is the interface for the card's calculation results.
 // Defaults to Record<string, number> for backward compatibility.
-export interface CardStrategy<TOutputs extends Record<string, any> = Record<string, number>> {
+export interface CardStrategy<TOutputs extends CardOutputRecord = Record<string, number>> {
     id: string; // The value stored in the selector (e.g., 'rect', 'h_beam')
     label: string;
 
@@ -159,14 +169,14 @@ type HiddenOutputField = {
 
 export type OutputFieldConfig = VisibleOutputField | HiddenOutputField;
 
-export interface CardDefinition<TOutputs extends Record<string, any> = Record<string, number>> {
+export interface CardDefinition<TOutputs extends CardOutputRecord = Record<string, number>> {
     type: string;             // Unique ID (e.g., 'SECTION', 'BEAM')
     title: string;            // Display Name
-    icon: React.FC<any>;      // Lucide Icon definition (renders as component)
+    icon: LucideIcon;         // Lucide Icon definition (renders as component)
     description?: string;
 
     // Default values for new cards
-    defaultInputs: Record<string, any>;
+    defaultInputs: Record<string, CardInput>;
 
     // Configuration for UI generation
 
@@ -199,7 +209,7 @@ export interface CardDefinition<TOutputs extends Record<string, any> = Record<st
     //   so calculate() doesn't need to filter inputs manually.
     calculate: (
         inputs: Record<string, number>,
-        rawInputs?: Record<string, any>,
+        rawInputs?: Record<string, CardInput>,
         dynamicGroups?: Record<string, Array<{ inputKey: string; outputKey: string; value: number }>>
     ) => TOutputs;
 

--- a/src/lib/utils/reportGenerator.ts
+++ b/src/lib/utils/reportGenerator.ts
@@ -23,7 +23,7 @@ const noopActions: CardActions = {
 };
 
 function renderVisualizationSvg(
-    def: import('../registry/types').CardDefinition,
+    def: import('../registry/types').CardDefinition<import('../registry/types').CardOutputRecord>,
     card: Card,
     upstreamCards: Card[],
 ): string | undefined {

--- a/src/store/useTsumikiStore.ts
+++ b/src/store/useTsumikiStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { v4 as uuidv4 } from 'uuid';
-import type { Card, CardType } from '../types';
+import type { Card, CardInput, CardType } from '../types';
 import { topologicalSort } from '../lib/engine/graph';
 import { registry } from '../lib/registry';
 import { applyExpression } from '../lib/utils/cardHelpers';
@@ -169,7 +169,7 @@ const recalculateAll = (cards: Card[]): Card[] => {
             // Skip calculate when a pre-calculation error (e.g. intra-card cycle) was detected
             if (!error) {
                 try {
-                    outputs = def.calculate(resolvedInputs, card.inputs, dynamicGroupsArg);
+                    outputs = def.calculate(resolvedInputs, card.inputs, dynamicGroupsArg) as Record<string, number>;
                 } catch (err) {
                     const message = err instanceof Error ? err.message : String(err);
                     if (import.meta.env.DEV) console.warn(`[Tsumiki] Card "${card.alias}" (${card.type}) calculation failed:`, message);
@@ -207,9 +207,9 @@ export const useTsumikiStore = create<TsumikiState>((set) => ({
         const def = registry.get(type);
 
         // Initial inputs from Registry
-        let initialInputs: Record<string, any> = {};
+        let initialInputs: Record<string, CardInput> = {};
         if (def) {
-            initialInputs = JSON.parse(JSON.stringify(def.defaultInputs));
+            initialInputs = JSON.parse(JSON.stringify(def.defaultInputs)) as Record<string, CardInput>;
         }
 
         const newCard: Card = {


### PR DESCRIPTION
## Summary

Closes #16

- `CardOutputRecord` 型エイリアスを `types.ts` に導入し、ジェネリック制約（`TOutputs extends ...`）に使用。TypeScript のインターフェースが `Record<string, unknown>` を満たせない制限への対処。`eslint-disable` は型エイリアス定義の **1箇所のみ**
- `icon: React.FC<any>` → `LucideIcon`（lucide-react の公式型）
- `defaultInputs / rawInputs` を `Record<string, CardInput>` に統一
- `CardActions.updateInput` の `value` を `string | number` に明示型付け
- `ResultsPanel.outputs` を `Record<string, number>` に変更
- `visualizationHelper` の `transformInputs` シグネチャを `Record<string, CardInput> → Record<string, number>` に具体化
- `SortableItemContext.attributes` を `DraggableAttributes`（@dnd-kit/core）に変更
- `GenericCard` の `SelectInput` / `InputRow` / `OutputRow` props を具体型に（`Card`, `CardActions`, `NumericInputField`, `SelectInputField`）
- `visualization` / `reportVisualization` を `React.FC<any>` → `React.FC<CardComponentProps>` に変更
- `selectors` / `standardInputs` フィルタに型述語を追加し型ナローイングを明示化

## Test plan

- [ ] `npx tsc --noEmit` — エラー 0
- [ ] `npm run lint` — エラー 0（`no-explicit-any` 含む）
- [ ] `npm run build` — ビルド成功
- [ ] Dev サーバーでカード追加・計算・参照が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)